### PR TITLE
ci: Publish kar bundle to release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,25 @@
+name: Publish bundle to nexus-casc-plugin release
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - run: mvn -B package --file pom.xml
+      - run: mkdir staging && cp target/*.kar staging
+      - name: Upload the artifacts
+        uses: skx/github-action-publish-binaries@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: 'staging/*'

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -1,0 +1,23 @@
+name: Build and test nexus-casc-plugin
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - run: mvn -B verify --file pom.xml
+      - run: mkdir staging && cp target/*.{k,j}ar staging
+      - uses: actions/upload-artifact@v2
+        with:
+          name: nexus-casc-plugin
+          path: staging


### PR DESCRIPTION
Adds a "verify" workflow, that:
  - builds and tests every commit to `master`
  - stores the jar and kar files for 90 days as artifact of the workflow

Adds a "release" workflow, that:
  - on release, builds the commit associated with that release
  - automatically publishes the build kar bundle to the release page

See https://github.com/csullivannet/nexus-casc-plugin/releases/tag/3.27.0-03 for an example, with the bundle available at https://github.com/csullivannet/nexus-casc-plugin/releases/download/3.27.0-03/nexus-casc-plugin-3.27.0-03-bundle.kar