### PR TITLE
feat(plugin) add support for all http config

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,17 @@ The format of the YAML file is documented below.
 
 Start Nexus as usual.
 
+## Local testing
+
+There is a `docker-compose.yml` file with all the necessary to test this. The test admin user is `johndoe` and its password
+is located in the `password_johndoe` file. The YAML configuration is located in `default-nexus.yml`. It has a non-working
+proxy configuration just to test its configuration. Removing `httpProxy` and/or `httpsProxy` entirely will also clear the relevant
+proxy settings on the next boot.
+```shell
+mvn package
+docker-compose run nexus
+```
+
 ## Configuration file
 
 You can find an example configuration file [here](https://github.com/AdaptiveConsulting/nexus-casc-plugin/blob/master/default-nexus.yml).
@@ -70,9 +81,26 @@ The configuration file supports following options:
 ```yaml
 core:
   baseUrl: "" # Nexus base URL
-  httpProxy: "" # HTTP proxy (Note: Basic Auth and NTLM are not yet supported, file an issue if you require this)
-  httpsProxy: ""  # HTTP proxy
-  nonProxyHosts: "" # Comma separated list of hosts not to be queried through a proxy
+  userAgentCustomization: ""
+  connectionTimeout: 0 # ignored if 0
+  connectionRetryAttempts: 0 # ignored if 0
+  httpProxy: # HTTP proxy
+    host: ""
+    port: 80 # defaults to 80
+    username: ""
+    password: ""
+    ntlmHost: ""
+    ntlmDomain: ""
+  httpsProxy: # HTTPs proxy
+    host: ""
+    port: 80 # still defaults to 80 because Nexus has no way to know that it needs to use TLS for the proxy itself
+    username: ""
+    password: ""
+    ntlmHost: ""
+    ntlmDomain: ""
+  nonProxyHosts: # list of hosts not to be queried through a proxy
+    - "host1"
+    - "hostn..."
 ```
 
 #### Security

--- a/default-nexus.yml
+++ b/default-nexus.yml
@@ -1,10 +1,24 @@
 ---
 core:
   baseUrl: ${BASE_URL:""}
-  httpProxy: ${HTTP_PROXY:""}
-  httpsProxy: ${HTTPS_PROXY:""}
-  # TODO: allow to have a list here...
-  nonProxyHosts: ${NO_PROXY:""}
+  userAgentCustomization: "CasC test"
+  connectionTimeout: 60
+  connectionRetryAttempts: 10
+  httpProxy:
+    host: proxy.internal.lan
+    port: 3128
+    username: nexus-user
+    password: ${PROXY_PASSWORD}
+  httpsProxy:
+    host: proxy.internal.lan
+    port: 3128
+    username: nexus-user
+    password: ${PROXY_PASSWORD}
+    ntlmHost: dc.internal.lan
+    ntlmDomain: internal.lan
+  nonProxyHosts:
+    - host1.internal.lan
+    - host2.internal.lan
 capabilities:
   - type: OutreachManagementCapability
     enabled: false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,8 @@ services:
       - '${NEXUS_UI_PORT}:8081'
       # - '18090:18090'
       # - '18091:18091'
+    expose:
+      - '${NEXUS_UI_PORT}'
     secrets:
       - password_johndoe
     ulimits:

--- a/src/main/java/com/weareadaptive/nexus/casc/plugin/internal/config/ConfigCore.java
+++ b/src/main/java/com/weareadaptive/nexus/casc/plugin/internal/config/ConfigCore.java
@@ -1,11 +1,15 @@
 package com.weareadaptive.nexus.casc.plugin.internal.config;
 
+import java.util.List;
+
 public class ConfigCore {
     private String baseUrl;
-    private String httpProxy;
-    private String httpsProxy;
-    // TODO: allow list of strings...
-    private String nonProxyHosts;
+    private String userAgentCustomization;
+    private int connectionTimeout;
+    private int connectionRetryAttempts;
+    private ConfigHttpProxy httpProxy;
+    private ConfigHttpProxy httpsProxy;
+    private List<String> nonProxyHosts;
 
     public String getBaseUrl() {
         return baseUrl;
@@ -15,27 +19,51 @@ public class ConfigCore {
         this.baseUrl = baseUrl;
     }
 
-    public String getHttpProxy() {
+    public void setUserAgentCustomization(String userAgentCustomization) {
+        this.userAgentCustomization = userAgentCustomization;
+    }
+
+    public String getUserAgentCustomization() {
+        return this.userAgentCustomization;
+    }
+
+    public void setConnectionTimeout(int connectionTimeout){
+        this.connectionTimeout = connectionTimeout;
+    }
+
+    public int getConnectionTimeout(){
+        return this.connectionTimeout;
+    }
+
+    public void setConnectionRetryAttempts(int connectionRetryAttempts) {
+        this.connectionRetryAttempts = connectionRetryAttempts;
+    }
+
+    public int getConnectionRetryAttempts(){
+        return this.connectionRetryAttempts;
+    }
+
+    public ConfigHttpProxy getHttpProxy() {
         return httpProxy;
     }
 
-    public void setHttpProxy(String httpProxy) {
+    public void setHttpProxy(ConfigHttpProxy httpProxy) {
         this.httpProxy = httpProxy;
     }
 
-    public String getHttpsProxy() {
+    public ConfigHttpProxy getHttpsProxy() {
         return httpsProxy;
     }
 
-    public void setHttpsProxy(String httpsProxy) {
+    public void setHttpsProxy(ConfigHttpProxy httpsProxy) {
         this.httpsProxy = httpsProxy;
     }
 
-    public String getNonProxyHosts() {
+    public List<String> getNonProxyHosts() {
         return nonProxyHosts;
     }
 
-    public void setNonProxyHosts(String nonProxyHosts) {
+    public void setNonProxyHosts(List<String> nonProxyHosts) {
         this.nonProxyHosts = nonProxyHosts;
     }
 }

--- a/src/main/java/com/weareadaptive/nexus/casc/plugin/internal/config/ConfigHttpProxy.java
+++ b/src/main/java/com/weareadaptive/nexus/casc/plugin/internal/config/ConfigHttpProxy.java
@@ -1,0 +1,59 @@
+package com.weareadaptive.nexus.casc.plugin.internal.config;
+
+public class ConfigHttpProxy {
+    private String host;
+    private int port;
+    private String username;
+    private String password;
+    private String ntlmHost;
+    private String ntlmDomain;
+
+
+    public String getHost() {
+        return host;
+    }
+
+    public void setHost(String host) {
+        this.host = host;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public void setPort(int port) {
+        this.port = port;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getNtlmHost() {
+        return ntlmHost;
+    }
+
+    public void setNtlmHost(String ntlmHost) {
+        this.ntlmHost = ntlmHost;
+    }
+
+    public String getNtlmDomain() {
+        return ntlmDomain;
+    }
+
+    public void setNtlmDomain(String ntlmDomain) {
+        this.ntlmDomain = ntlmDomain;
+    }
+}


### PR DESCRIPTION
Adresses issue #17 

# Breaking changes

Added all necessary fields for complete proxy configuration according to what Nexus supports. This means that operating system `HTTP_PROXY` environment variable don't work as is anymore.

The `nonProxyHosts` field is now also a list. Which is closer to how it is represented in Nexus administration UI.