### PR TITLE
Add ability to configure multiple capabilities of the same type

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>com.weareadaptive.nexus</groupId>
     <artifactId>nexus-casc-plugin</artifactId>
-    <version>3.33.1-01</version>
+    <version>3.33.1-02</version>
     <packaging>bundle</packaging>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>com.weareadaptive.nexus</groupId>
     <artifactId>nexus-casc-plugin</artifactId>
-    <version>3.33.1-02</version>
+    <version>3.33.1-01</version>
     <packaging>bundle</packaging>
 
     <properties>

--- a/src/main/java/com/weareadaptive/nexus/casc/plugin/internal/NexusCascPlugin.java
+++ b/src/main/java/com/weareadaptive/nexus/casc/plugin/internal/NexusCascPlugin.java
@@ -227,12 +227,24 @@ public class NexusCascPlugin extends StateGuardLifecycleSupport {
                 if (existingWithType != null) {
                     int bestMatch = Integer.MAX_VALUE; // Smaller is better
                     for (int i = 0; i < existingWithType.size(); ++i) {
-                        Map<String, String> properties = existingWithType.get(i).properties();
+                        Map<String, String> existingProperties = existingWithType.get(i).properties();
+                        Map<String, String> configProperties = capabilityConfig.getAttributes();
 
-                        int mismatchedPropertyCount = Math.max(properties.size(), capabilityConfig.getAttributes().size());
-                        for (Map.Entry<String, String> prop : capabilityConfig.getAttributes().entrySet()) {
-                            if (Objects.equals(prop.getValue(), properties.get(prop.getKey()))) {
-                                --mismatchedPropertyCount;
+                        int mismatchedPropertyCount;
+                        if(configProperties == null) {
+                            mismatchedPropertyCount = existingProperties == null ? 0 : existingProperties.size();
+                        } else if(existingProperties == null) {
+                            mismatchedPropertyCount = configProperties.size();
+                        } else {
+                            Set<String> totalKeys = new HashSet<>(existingProperties.size());
+                            totalKeys.addAll(existingProperties.keySet());
+                            totalKeys.addAll(configProperties.keySet());
+
+                            mismatchedPropertyCount = totalKeys.size();
+                            for (String key : totalKeys) {
+                                if (Objects.equals(configProperties.get(key), existingProperties.get(key))) {
+                                    --mismatchedPropertyCount;
+                                }
                             }
                         }
 

--- a/src/main/java/com/weareadaptive/nexus/casc/plugin/internal/config/Config.java
+++ b/src/main/java/com/weareadaptive/nexus/casc/plugin/internal/config/Config.java
@@ -6,6 +6,7 @@ public class Config {
     private ConfigCore core;
     private ConfigRepository repository;
     private ConfigSecurity security;
+    private Boolean pruneCapabilitiesByType;
     private List<ConfigCapability> capabilities;
 
     public ConfigCore getCore() {
@@ -30,6 +31,14 @@ public class Config {
 
     public void setSecurity(ConfigSecurity security) {
         this.security = security;
+    }
+
+    public Boolean getPruneCapabilitiesByType() {
+        return pruneCapabilitiesByType;
+    }
+
+    public void setPruneCapabilitiesByType(Boolean pruneCapabilitiesByType) {
+        this.pruneCapabilitiesByType = pruneCapabilitiesByType;
     }
 
     public List<ConfigCapability> getCapabilities() {


### PR DESCRIPTION
Nexus allows multiple instances of a capability to be created, as long as at least one of a certain subset of its properties is unique.

Previously, the CASC plugin would assume that only a single capability of any given type can exist, so would always replace any existing capability of the mathching type, even if it has only just been created by the CASC config itself.

This PR changes that behaviour:
  - Only capabilities that existed _before_ the CASC configuration was applied are candidates for replacement
  - If there are multiple existing capabilities of a matching type, a "best match" is found by comparing properties/attribute values
  - Once a match has been found between an existing capability and a capability config in the CASC, that existing capability will be removed from the candidate pool for matching against any subsequent capability configs defined in the CASC.
  - If the new `pruneCapabilitiesByType` config option is specified, any existing capabilities that aren't matched against capability configs will removed. This only applies to capabilities whose type matches at least one capability config in the CASC.