### PR TITLE
Add option to prune roles not specified in CASC

### DIFF
--- a/src/main/java/com/weareadaptive/nexus/casc/plugin/internal/NexusCascPlugin.java
+++ b/src/main/java/com/weareadaptive/nexus/casc/plugin/internal/NexusCascPlugin.java
@@ -48,7 +48,11 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.*;
+import java.util.function.Function;
 import java.util.stream.Collectors;
+
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.toList;
 
 @Named("cascPlugin")
 @Description("Casc Plugin")
@@ -509,66 +513,70 @@ public class NexusCascPlugin extends StateGuardLifecycleSupport {
         }
 
         if (security.getRoles() != null) {
-            List<String> sources = security.getRoles().stream().map(ConfigSecurityRole::getSource).distinct().collect(Collectors.toList());
+            boolean pruneRolesBySource = security.getPruneRolesBySource();
+            Map<String, List<ConfigSecurityRole>> rolesBySource = security.getRoles().stream()
+                    .collect(groupingBy(ConfigSecurityRole::getSource, toList()));
+            for (Map.Entry<String, List<ConfigSecurityRole>> ent : rolesBySource.entrySet()) {
+                String source = ent.getKey();
+                List<ConfigSecurityRole> roles = ent.getValue();
+                try {
+                    AuthorizationManager authManager = securitySystem.getAuthorizationManager(source);
+                    if (!authManager.supportsWrite())
+                        throw new NotWritableException("AuthorizationManager: " + source);
 
-            if (sources != null) {
-                sources.forEach(source -> {
-                    try {
-                        AuthorizationManager authManager = securitySystem.getAuthorizationManager(source);
-                        if (!authManager.supportsWrite())
-                            throw new NotWritableException("AuthorizationManager: " + source);
-                        List<ConfigSecurityRole> roles = security.getRoles().stream().filter(p -> p.getSource().contentEquals(source)).collect(Collectors.toList());
-                        if (roles != null) {
-                            for (ConfigSecurityRole r : roles) {
-                                if (r.isEnabled()) {
-                                    Role tmpRole;
-                                    Boolean update = false;
-                                    try {
-                                        tmpRole = authManager.getRole(r.getId());
-                                        update = true;
-                                        tmpRole.setName(r.getName());
-                                        tmpRole.setDescription(r.getDescription());
-                                        tmpRole.setReadOnly(false);
-                                        tmpRole.setRoles(r.getRoles().stream().collect(Collectors.toSet()));
-                                        tmpRole.setPrivileges(r.getPrivileges().stream().collect(Collectors.toSet()));
-                                    } catch (NoSuchRoleException e) {
-                                        tmpRole = new Role(
-                                                r.getId(),
-                                                r.getName(),
-                                                r.getDescription(),
-                                                r.getSource(),
-                                                false,
-                                                r.getRoles() != null ? r.getRoles().stream().distinct().collect(Collectors.toSet()) : null,
-                                                r.getPrivileges() != null ? r.getPrivileges().stream().distinct().collect(Collectors.toSet()) : null
-                                        );
-                                    }
+                    // Remove roles first, so we fail fast if an enabled role references a removed one
+                    Set<String> idsToRemove = new HashSet<>();
+                    if(pruneRolesBySource) {
+                        authManager.listRoles().stream().map(Role::getRoleId).forEach(idsToRemove::add);
+                    }
+                    for (ConfigSecurityRole role : roles) {
+                        if (role.isEnabled()) {
+                            idsToRemove.remove(role.getId());
+                        } else {
+                            idsToRemove.add(role.getId());
+                        }
+                    }
+                    for (String roleId : idsToRemove) {
+                        log.info("Deleting role {}", roleId);
+                        authManager.deleteRole(roleId);
+                    }
 
-                                    try {
-                                        if (update) {
-                                            log.info("Updating role {}", r.getId());
-                                            authManager.updateRole(tmpRole);
+                    for (ConfigSecurityRole r : roles) {
+                        if (r.isEnabled()) {
+                            Role tmpRole;
+                            boolean update = false;
+                            try {
+                                tmpRole = authManager.getRole(r.getId());
+                                update = true;
+                            } catch (NoSuchRoleException e) {
+                                tmpRole = new Role();
+                                tmpRole.setRoleId(r.getId());
+                                tmpRole.setSource(r.getSource());
+                            }
+                            tmpRole.setName(r.getName());
+                            tmpRole.setDescription(r.getDescription());
+                            tmpRole.setReadOnly(false);
+                            tmpRole.setRoles(r.getRoles() == null ? null : new HashSet<>(r.getRoles()));
+                            tmpRole.setPrivileges(r.getPrivileges() == null ? null : new HashSet<>(r.getPrivileges()));
 
-                                        } else {
-                                            log.info("Creating role {}", r.getId());
-                                            authManager.addRole(tmpRole);
-                                        }
-                                    } catch (RuntimeException e) {
-                                        log.error("Failed to create/update role {}", r.getId(), e);
-                                    }
+                            try {
+                                if (update) {
+                                    log.info("Updating role {}", r.getId());
+                                    authManager.updateRole(tmpRole);
                                 } else {
-                                    log.info("Deleting role {}", r.getId());
-                                    authManager.deleteRole(r.getId());
+                                    log.info("Creating role {}", r.getId());
+                                    authManager.addRole(tmpRole);
                                 }
+                            } catch (RuntimeException e) {
+                                log.error("Failed to create/update role {}", r.getId(), e);
                             }
                         }
-                    } catch (NoSuchAuthorizationManagerException e) {
-                        log.error("AuthorizationManager {} does not exist.", source, e);
-                    } catch (NotWritableException e) {
-                        log.error("AuthorizationManager {} is not writable", source, e);
                     }
-                });
-            } else {
-                log.info("No sources were available for roles");
+                } catch (NoSuchAuthorizationManagerException e) {
+                    log.error("AuthorizationManager {} does not exist.", source, e);
+                } catch (NotWritableException e) {
+                    log.error("AuthorizationManager {} is not writable", source, e);
+                }
             }
         }
 
@@ -629,7 +637,7 @@ public class NexusCascPlugin extends StateGuardLifecycleSupport {
                             userConfig.getEmail(),
                             userConfig.getActive() != null ? userConfig.getActive() : true,
                             userConfig.getPassword(),
-                            userConfig.getRoles().stream().map(ConfigSecurityUserRole::getRole).collect(Collectors.toList())
+                            userConfig.getRoles().stream().map(ConfigSecurityUserRole::getRole).collect(toList())
                     );
                 }
             });

--- a/src/main/java/com/weareadaptive/nexus/casc/plugin/internal/config/ConfigSecurity.java
+++ b/src/main/java/com/weareadaptive/nexus/casc/plugin/internal/config/ConfigSecurity.java
@@ -5,6 +5,7 @@ import java.util.List;
 public class ConfigSecurity {
     private Boolean anonymousAccess;
     private Boolean pruneUsers;
+    private Boolean pruneRolesBySource;
     private List<ConfigSecurityPrivilege> privileges;
     private List<ConfigSecurityRole> roles;
     private List<ConfigSecurityUser> users;
@@ -24,6 +25,14 @@ public class ConfigSecurity {
 
     public void setPruneUsers(Boolean pruneUsers) {
         this.pruneUsers = pruneUsers;
+    }
+
+    public Boolean getPruneRolesBySource() {
+        return pruneRolesBySource;
+    }
+
+    public void setPruneRolesBySource(Boolean pruneRolesBySource) {
+        this.pruneRolesBySource = pruneRolesBySource;
     }
 
     public List<ConfigSecurityPrivilege> getPrivileges() { return privileges; }


### PR DESCRIPTION
This PR adds an additional option to the security config: `pruneRolesBySource`. If this is set to true, then for each role source that has at least one role specified in the CASC file, the plugin will delete any roles _not_ specified in the casc file.

This allows for certain scenarios that were not easily catered for by the old behaviour of the plugin, such as changing the name of a role in the CASC file, then reapplying.