### PR TITLE
Use correct name in example configuration documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,13 +205,13 @@ repository:
       format: maven2
       notes: ''
       criteria:
-        lastDownloadBefore: 864000
+        lastDownloaded: 864000
         lastBlobUpdated: 864000
     - name: cleanup-npm-proxy
       format: npm
       notes: ''
       criteria:
-        lastDownloadBefore: 864000
+        lastDownloaded: 864000
     - name: cleanup-docker-proxy
       format: docker
       notes: ''


### PR DESCRIPTION
At first, thank you for the great project, it helps me a lot.

This PR fixes the example documentation by replacing ``lastDownloadBefore`` with ``lastDownloaded``.

When updating to Nexus 3.38.1 ``lastDownloadBefore`` resulted in an infinitive loop that occurred when the cleanup was executed:
```
2022-04-29 01:00:00,213+0000 ERROR [quartz-9-thread-20]  *SYSTEM org.sonatype.nexus.cleanup.internal.orient.service.OrientCleanupServiceImpl - Failed to delete components.
java.lang.UnsupportedOperationException: Criteria of type lastDownloadBefore is not supported
        at org.sonatype.nexus.cleanup.internal.search.elasticsearch.AbstractSearchCleanupComponentBrowse.addCriteria(AbstractSearchCleanupComponentBrowse.java:170)
        at org.sonatype.nexus.cleanup.internal.search.elasticsearch.AbstractSearchCleanupComponentBrowse.convertPolicyToQuery(AbstractSearchCleanupComponentBrowse.java:162)
        at org.sonatype.nexus.cleanup.internal.search.elasticsearch.AbstractSearchCleanupComponentBrowse.browse(AbstractSearchCleanupComponentBrowse.java:83)
        at org.sonatype.nexus.cleanup.internal.orient.service.OrientCleanupServiceImpl.deleteByPolicy(OrientCleanupServiceImpl.java:129)
        at org.sonatype.nexus.cleanup.internal.orient.service.OrientCleanupServiceImpl.lambda$1(OrientCleanupServiceImpl.java:108)
        at java.util.ArrayList.forEach(ArrayList.java:1259)
        at org.sonatype.nexus.cleanup.internal.orient.service.OrientCleanupServiceImpl.cleanup(OrientCleanupServiceImpl.java:107)
        at org.sonatype.nexus.cleanup.internal.orient.service.OrientCleanupServiceImpl.lambda$0(OrientCleanupServiceImpl.java:97)
        at com.google.common.collect.ImmutableList.forEach(ImmutableList.java:406)
        at org.sonatype.nexus.cleanup.internal.orient.service.OrientCleanupServiceImpl.cleanup(OrientCleanupServiceImpl.java:95)
        at org.sonatype.nexus.cleanup.internal.task.CleanupTask.execute(CleanupTask.java:46)
        at org.sonatype.nexus.scheduling.TaskSupport.call(TaskSupport.java:100)
        at org.sonatype.nexus.quartz.internal.task.QuartzTaskJob.doExecute(QuartzTaskJob.java:143)
        at org.sonatype.nexus.quartz.internal.task.QuartzTaskJob.execute(QuartzTaskJob.java:106)
        at org.quartz.core.JobRunShell.run(JobRunShell.java:202)
        at org.sonatype.nexus.quartz.internal.QuartzThreadPool.lambda$0(QuartzThreadPool.java:145)
        at org.sonatype.nexus.thread.internal.MDCAwareRunnable.run(MDCAwareRunnable.java:40)
        at org.apache.shiro.subject.support.SubjectRunnable.doRun(SubjectRunnable.java:120)
        at org.apache.shiro.subject.support.SubjectRunnable.run(SubjectRunnable.java:108)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
```

This in term caused a full disk which crashed the server.

The solution was to use the correct key (can be found inside the Nexus-source code here: https://github.com/sonatype/nexus-public/blob/1ecf4910f7f3c9b284fae981f2b9bd5443f0822f/components/nexus-cleanup-config/src/main/java/org/sonatype/nexus/cleanup/config/CleanupPolicyConstants.java#L30)