### PR TITLE
Run release/publish workflow on tag pushes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,23 +4,34 @@ name: Publish bundle to nexus-casc-plugin release
 on:
   release:
     types: [created]
+  push:
+    tags:
+      - v*
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
-          java-version: 1.8
-      - run: ./mvnw -B package --file pom.xml
-      - run: mkdir staging && cp target/*.kar staging
-      - name: Upload the artifacts
-        uses: skx/github-action-publish-binaries@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          java-version: 8
+          distribution: 'adopt'
+
+      - name: Build
+        run: ./mvnw -B package --file pom.xml
+
+      - name: Stage
+        run: mkdir staging && cp target/*.kar staging
+
+      - name: release
+        uses: ncipollo/release-action@v1
+        id: create_release
         with:
-          args: 'staging/*'
+          artifacts: 'staging/*'


### PR DESCRIPTION
This changes the behaviour of the release workflow. It will now trigger on pushed tags, and publish a new release with the produced kar file.

Upgraded actions to latest versions to fix deprecation warnings in github actions.

This is to fix the current pipeline which needs a new release to be manually created.

This workflow is run when a new tag is pushed; `git tag v0xx && git push --tags`.