### PR TITLE
Add handling of repository routing rules

### DIFF
--- a/src/main/java/com/weareadaptive/nexus/casc/plugin/internal/config/ConfigRepository.java
+++ b/src/main/java/com/weareadaptive/nexus/casc/plugin/internal/config/ConfigRepository.java
@@ -10,6 +10,8 @@ public class ConfigRepository {
     private Boolean pruneRepositories;
     private List<ConfigRepositoryEntry> repositories;
 
+    private List<ConfigRoutingRule> routingRules;
+
     public Boolean getPruneBlobStores() {
         return pruneBlobStores;
     }
@@ -57,4 +59,13 @@ public class ConfigRepository {
     public void setRepositories(List<ConfigRepositoryEntry> repositories) {
         this.repositories = repositories;
     }
+
+    public List<ConfigRoutingRule> getRoutingRules() {
+        return routingRules;
+    }
+
+    public void setRoutingRules(List<ConfigRoutingRule> routingRules) {
+        this.routingRules = routingRules;
+    }
+
 }

--- a/src/main/java/com/weareadaptive/nexus/casc/plugin/internal/config/ConfigRepositoryEntry.java
+++ b/src/main/java/com/weareadaptive/nexus/casc/plugin/internal/config/ConfigRepositoryEntry.java
@@ -1,5 +1,7 @@
 package com.weareadaptive.nexus.casc.plugin.internal.config;
 
+import org.sonatype.nexus.common.entity.EntityId;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -8,6 +10,8 @@ public class ConfigRepositoryEntry {
     private String recipeName;
     private Boolean online;
     private Map<String, Map<String, Object>> attributes = new HashMap<>();
+
+    private String routingRuleName;
 
     public String getName() {
         return name;
@@ -40,4 +44,12 @@ public class ConfigRepositoryEntry {
     public void setAttributes(Map<String, Map<String, Object>> attributes) {
         this.attributes = attributes;
     }
+    public String getRoutingRuleName() {
+        return routingRuleName;
+    }
+
+    public void setRoutingRuleName(String routingRuleName) {
+        this.routingRuleName = routingRuleName;
+    }
+
 }

--- a/src/main/java/com/weareadaptive/nexus/casc/plugin/internal/config/ConfigRoutingRule.java
+++ b/src/main/java/com/weareadaptive/nexus/casc/plugin/internal/config/ConfigRoutingRule.java
@@ -1,0 +1,42 @@
+package com.weareadaptive.nexus.casc.plugin.internal.config;
+
+import java.util.List;
+
+public class ConfigRoutingRule {
+    private String name;
+    private String description;
+    private String mode;
+    private List<String> matchers;
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getMode() {
+        return mode;
+    }
+
+    public void setMode(String mode) {
+        this.mode = mode;
+    }
+
+    public List<String> getMatchers() {
+        return matchers;
+    }
+
+    public void setMatchers(List<String> matchers) {
+        this.matchers = matchers;
+    }
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+}


### PR DESCRIPTION
This pull requests adds support for adding routing rules.

Example configuration:
```yaml
repository:
  routingRules:
    - name: go-internal
      description: internal golang packages with authentication
      mode: ALLOW
      matchers:
        - ".*/github.com/<private-organization>/.*"
...
    - name: athens
      recipeName: go-proxy
      online: true
      routingRuleName: go-internal
      attributes:
        proxy:
          remoteUrl: http://athens.athens.svc.cluster.local:8080
          contentMaxAge: 10080
          metadataMaxAge: 1440
...
```